### PR TITLE
Fixes for RequestStatus throwing Rack::Lint::LintError: errors

### DIFF
--- a/lib/rack-statsd.rb
+++ b/lib/rack-statsd.rb
@@ -39,8 +39,11 @@ module RackStatsD
     def call(env)
       if env[REQUEST_METHOD] == GET
         if env[PATH_INFO] == @status_path
-          method = @callback.respond_to?(:call) ? :call : :to_s
-          return [200, {}, @callback.send(method)]
+          if @callback.respond_to?(:call)
+            return @callback.call
+          else
+            return [200, {"Content-Type" => "text/plain"}, [@callback.to_s]]    
+          end
         end
       end
 


### PR DESCRIPTION
'No Content-Type header found' was being thrown due to an empty {}
being returned.

'Response body must respond to each' was being thrown due to "" no
longer responding to each as it did in ruby 1.8.7.

Both of these fixes are necessary for the call(env) method on the RequestStatus
class to respond properly. The gem currently does not have a test suite
to verify these changes, but I've confirmed each example in the comments for
RequestStatus responds correctly.
