### PR TITLE
don't freeze RequestStatus HEADERS hash

### DIFF
--- a/lib/rack-statsd.rb
+++ b/lib/rack-statsd.rb
@@ -7,7 +7,7 @@ module RackStatsD
     GET            = 'GET'.freeze
     PATH_INFO      = 'PATH_INFO'.freeze
     STATUS_PATH    = '/status'
-    HEADERS        = {"Content-Type" => "text/plain"}.freeze
+    HEADERS        = {"Content-Type" => "text/plain"}
 
     # Initializes the middleware.
     #


### PR DESCRIPTION
If the hash is frozen, it prevents subsequent middleware (i.e. RackStatsD::RequestHostname) from modifying the response headers.
